### PR TITLE
LPS-24719, Missed svn friendly url routes

### DIFF
--- a/portlets/social-coding-portlet/docroot/WEB-INF/src/com/liferay/socialcoding/svn/portlet/svn-friendly-url-routes.xml
+++ b/portlets/social-coding-portlet/docroot/WEB-INF/src/com/liferay/socialcoding/svn/portlet/svn-friendly-url-routes.xml
@@ -3,6 +3,10 @@
 
 <routes>
 	<route>
+		<pattern></pattern>
+		<implicit-parameter name="jspPage">/svn/view.jsp</implicit-parameter>
+	</route>
+	<route>
 		<pattern>/rss/all/plugin/trunk</pattern>
 		<implicit-parameter name="all">1</implicit-parameter>
 		<implicit-parameter name="p_p_state">exclusive</implicit-parameter>


### PR DESCRIPTION
I missed one svn friendly URL and here the commit for it.
But here's explanation why I didn't change for other ones:
1. chat-friendly-url is not conventional layout portlet that we would show sharing.
2. admin-friendly-url is control panel portlet and it's unnecessary.
3. For article-friendly-url, the portlet is using admin/common/view_article and it's smart enough render. But it would not hurt us if we do add the same pattern.
