### PR TITLE
LPS-29955 Users in the Control Panel only display one page when using the Solr Web Plugin

### DIFF
--- a/webs/solr-web/docroot/WEB-INF/src/com/liferay/portal/search/solr/SolrIndexSearcherImpl.java
+++ b/webs/solr-web/docroot/WEB-INF/src/com/liferay/portal/search/solr/SolrIndexSearcherImpl.java
@@ -352,7 +352,7 @@ public class SolrIndexSearcherImpl implements IndexSearcher {
 		}
 
 		hits.setDocs(documents.toArray(new Document[subsetTotal]));
-		hits.setLength(subsetTotal);
+		hits.setLength((int)total);
 		hits.setQuery(query);
 		hits.setQueryTerms(queryTerms.toArray(new String[queryTerms.size()]));
 


### PR DESCRIPTION
should pass total instead of subsetTotal into the setLength()
