### PR TITLE
LPS-47087 remove unnecessary code

### DIFF
--- a/webs/sync-web/docroot/WEB-INF/src/com/liferay/sync/hook/security/auth/SyncAuthVerifier.java
+++ b/webs/sync-web/docroot/WEB-INF/src/com/liferay/sync/hook/security/auth/SyncAuthVerifier.java
@@ -93,8 +93,6 @@ public class SyncAuthVerifier extends BaseAutoLogin implements AuthVerifier {
 					clazz, "doLogin", HttpServletRequest.class,
 					HttpServletResponse.class);
 
-				method.setAccessible(true);
-
 				String[] credentials = (String[])method.invoke(
 					object, request, response);
 


### PR DESCRIPTION
Since getDeclaredMethod method of class ReflectionUtil already call method.setAccessible(true); so 
the code method.setAccessible(true); is unnecessary
