### PR TITLE
LPS-48297 LPS-48297 After enable Akismet for Wiki, Wiki page starts from...

### DIFF
--- a/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/action/AkismetEditPageAction.java
+++ b/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/action/AkismetEditPageAction.java
@@ -178,12 +178,7 @@ public class AkismetEditPageAction extends BaseStrutsPortletAction {
 						wikiPage.getTitle(), previousVersion, serviceContext);
 				}
 				else {
-					WikiPageLocalServiceUtil.updatePage(
-						themeDisplay.getUserId(), wikiPage.getNodeId(),
-						wikiPage.getTitle(), latestVersion, null,
-						StringPool.BLANK, true, wikiPage.getFormat(),
-						wikiPage.getParentTitle(), wikiPage.getRedirectTitle(),
-						serviceContext);
+					return ;
 				}
 			}
 

--- a/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/service/impl/AkismetWikiPageLocalServiceImpl.java
+++ b/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/service/impl/AkismetWikiPageLocalServiceImpl.java
@@ -99,16 +99,8 @@ public class AkismetWikiPageLocalServiceImpl
 			page.setSummary(AkismetConstants.WIKI_PAGE_PENDING_APPROVAL);
 			page.setStatus(WorkflowConstants.STATUS_APPROVED);
 
-			page = super.updateWikiPage(page);
+			return super.updateWikiPage(page);
 
-			ServiceContext newServiceContext = new ServiceContext();
-
-			newServiceContext.setFormDate(page.getModifiedDate());
-
-			return super.updatePage(
-				userId, nodeId, title, page.getVersion(), null,
-				StringPool.BLANK, true, format, parentTitle, redirectTitle,
-				newServiceContext);
 		}
 		finally {
 			NotificationThreadLocal.setEnabled(notificationEnabled);


### PR DESCRIPTION
Let me focus on the version problem only.

In the original cold, the WikiPageLocalServiceUtil.updatePage() is called after a wikipage is marked as spam which lead to returning a new page whose version is one larger than the old one. 

As I said, the version of page before marking as spam and after marking as spam should remain the same if the reverting to its old version is not triggered. So the I think the updatePage should not be called and just return the page with setting it as spam. 
