### PR TITLE
LPS-48297 Akismet wiki page version problem

### DIFF
--- a/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/action/AkismetEditPageAction.java
+++ b/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/action/AkismetEditPageAction.java
@@ -177,14 +177,6 @@ public class AkismetEditPageAction extends BaseStrutsPortletAction {
 						themeDisplay.getUserId(), wikiPage.getNodeId(),
 						wikiPage.getTitle(), previousVersion, serviceContext);
 				}
-				else {
-					WikiPageLocalServiceUtil.updatePage(
-						themeDisplay.getUserId(), wikiPage.getNodeId(),
-						wikiPage.getTitle(), latestVersion, null,
-						StringPool.BLANK, true, wikiPage.getFormat(),
-						wikiPage.getParentTitle(), wikiPage.getRedirectTitle(),
-						serviceContext);
-				}
 			}
 
 			// Akismet

--- a/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/service/impl/AkismetWikiPageLocalServiceImpl.java
+++ b/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/service/impl/AkismetWikiPageLocalServiceImpl.java
@@ -99,16 +99,7 @@ public class AkismetWikiPageLocalServiceImpl
 			page.setSummary(AkismetConstants.WIKI_PAGE_PENDING_APPROVAL);
 			page.setStatus(WorkflowConstants.STATUS_APPROVED);
 
-			page = super.updateWikiPage(page);
-
-			ServiceContext newServiceContext = new ServiceContext();
-
-			newServiceContext.setFormDate(page.getModifiedDate());
-
-			return super.updatePage(
-				userId, nodeId, title, page.getVersion(), null,
-				StringPool.BLANK, true, format, parentTitle, redirectTitle,
-				newServiceContext);
+			return super.updateWikiPage(page);
 		}
 		finally {
 			NotificationThreadLocal.setEnabled(notificationEnabled);


### PR DESCRIPTION
I closed the pull for you as the return should not be there. It is my mistake, sorry for that. 
The old code is always trying to return a new page with different version to the old one. And I think it is a wrong logic. 
For the addPage() method, it should return the created page marked as spam and for the updateSummary() method, the user should still see the unchanged last version if its previous version is marked as spam.
That is my logic.
