### PR TITLE
LPS-48297 After enable Akismet for Wiki, Wiki page starts from 1.1 version.

### DIFF
--- a/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/action/AkismetEditPageAction.java
+++ b/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/action/AkismetEditPageAction.java
@@ -177,14 +177,6 @@ public class AkismetEditPageAction extends BaseStrutsPortletAction {
 						themeDisplay.getUserId(), wikiPage.getNodeId(),
 						wikiPage.getTitle(), previousVersion, serviceContext);
 				}
-				else {
-					WikiPageLocalServiceUtil.updatePage(
-						themeDisplay.getUserId(), wikiPage.getNodeId(),
-						wikiPage.getTitle(), latestVersion, null,
-						StringPool.BLANK, true, wikiPage.getFormat(),
-						wikiPage.getParentTitle(), wikiPage.getRedirectTitle(),
-						serviceContext);
-				}
 			}
 
 			// Akismet

--- a/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/service/impl/AkismetWikiPageLocalServiceImpl.java
+++ b/portlets/akismet-portlet/docroot/WEB-INF/src/com/liferay/akismet/hook/service/impl/AkismetWikiPageLocalServiceImpl.java
@@ -66,11 +66,6 @@ public class AkismetWikiPageLocalServiceImpl
 
 		boolean enabled = isWikiEnabled(userId, nodeId, serviceContext);
 
-		if (enabled) {
-			serviceContext.setWorkflowAction(
-				WorkflowConstants.ACTION_SAVE_DRAFT);
-		}
-
 		WikiPage page = super.addPage(
 			userId, nodeId, title, version, content, summary, minorEdit, format,
 			head, parentTitle, redirectTitle, serviceContext);
@@ -99,16 +94,7 @@ public class AkismetWikiPageLocalServiceImpl
 			page.setSummary(AkismetConstants.WIKI_PAGE_PENDING_APPROVAL);
 			page.setStatus(WorkflowConstants.STATUS_APPROVED);
 
-			page = super.updateWikiPage(page);
-
-			ServiceContext newServiceContext = new ServiceContext();
-
-			newServiceContext.setFormDate(page.getModifiedDate());
-
-			return super.updatePage(
-				userId, nodeId, title, page.getVersion(), null,
-				StringPool.BLANK, true, format, parentTitle, redirectTitle,
-				newServiceContext);
+			return super.updateWikiPage(page);
 		}
 		finally {
 			NotificationThreadLocal.setEnabled(notificationEnabled);
@@ -132,11 +118,6 @@ public class AkismetWikiPageLocalServiceImpl
 		}
 
 		boolean enabled = isWikiEnabled(userId, nodeId, serviceContext);
-
-		if (enabled) {
-			serviceContext.setWorkflowAction(
-				WorkflowConstants.ACTION_SAVE_DRAFT);
-		}
 
 		WikiPage page = super.updatePage(
 			userId, nodeId, title, version, content, summary, minorEdit, format,
@@ -181,10 +162,7 @@ public class AkismetWikiPageLocalServiceImpl
 					newServiceContext);
 			}
 			else {
-				return super.updatePage(
-					userId, nodeId, title, page.getVersion(), null,
-					StringPool.BLANK, true, format, parentTitle, redirectTitle,
-					newServiceContext);
+				return page;
 			}
 		}
 		finally {


### PR DESCRIPTION
The logic of old code tried to return an empty page when the page is marked as spam.
But if a user tried to edit the empty page or mark it as spam, it could cause the problem of multiple versions of this page is marked as spam. And the action to the empty page does not make sense. So, the old design  might lead to confusion.

So, I am trying to just return the page after it is marked as spam or edited. 
