### PR TITLE
SOS-2489 - Javascript becomes inoperative when SO Announcements portlet ...

### DIFF
--- a/portlets/so-announcements-portlet/docroot/view.jsp
+++ b/portlets/so-announcements-portlet/docroot/view.jsp
@@ -61,7 +61,7 @@ if (group.isUser() && !showManageEntries) {
 		}
 	);
 
-	var announcementEntries = A.one('#p_p_id<portlet:namespace /> .portlet-content-container');
+	var announcementEntries = A.one('#p_p_id<portlet:namespace />');
 
 	announcementEntries.delegate(
 		'click',


### PR DESCRIPTION
this issue is caused by "SOS-1772",and "SOS-1772" only affect "ee-6.1.2.ga2",so it should not be applied to ee-6.1.x、6.2.x and trunk.

change
   var announcementEntries = A.one('#p_p_id<portlet:namespace /> .portlet-content-container');
to
  var announcementEntries = A.one('#p_p_id<portlet:namespace />');
