### PR TITLE
LPS-45034

### DIFF
--- a/webs/kaleo-web/docroot/WEB-INF/src/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
+++ b/webs/kaleo-web/docroot/WEB-INF/src/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
@@ -410,7 +410,7 @@ public class KaleoTaskInstanceTokenLocalServiceImpl
 			"workflowContext");
 
 		dynamicQuery.add(
-			workflowContextProperty.like("%\"userId\":" + userId + "%"));
+			workflowContextProperty.like("%\"userId\":\"" + userId + "\"%"));
 
 		addCompletedCriterion(dynamicQuery, completed);
 
@@ -432,7 +432,7 @@ public class KaleoTaskInstanceTokenLocalServiceImpl
 			"workflowContext");
 
 		dynamicQuery.add(
-			workflowContextProperty.like("%\"userId\":" + userId + "%"));
+			workflowContextProperty.like("%\"userId\":\"" + userId + "\"%"));
 
 		addCompletedCriterion(dynamicQuery, completed);
 

--- a/webs/kaleo-web/docroot/WEB-INF/src/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
+++ b/webs/kaleo-web/docroot/WEB-INF/src/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
@@ -409,7 +409,8 @@ public class KaleoTaskInstanceTokenLocalServiceImpl
 		Property workflowContextProperty = PropertyFactoryUtil.forName(
 			"workflowContext");
 
-		dynamicQuery.add(workflowContextProperty.like("\"userId\":" + userId));
+		dynamicQuery.add(
+			workflowContextProperty.like("%\"userId\":" + userId + "%"));
 
 		addCompletedCriterion(dynamicQuery, completed);
 
@@ -430,7 +431,8 @@ public class KaleoTaskInstanceTokenLocalServiceImpl
 		Property workflowContextProperty = PropertyFactoryUtil.forName(
 			"workflowContext");
 
-		dynamicQuery.add(workflowContextProperty.like("\"userId\":" + userId));
+		dynamicQuery.add(
+			workflowContextProperty.like("%\"userId\":" + userId + "%"));
 
 		addCompletedCriterion(dynamicQuery, completed);
 


### PR DESCRIPTION
Hi Hugo,

I add one addition fix to avoid similiar userId returned by using quotes as mark. 

By referring to https://github.com/hhuijser/liferay-plugins/pull/171,
the data like as the below content:
###
{"map":..."workflowAction":1,"userId":10205,"...,"entryClassName":"com.liferay.portlet.blogs.model.BlogsEntry","groupId":"10186","entryType":"Blogs Entry","userId":"10205","taskComments":"","companyId":"10156","entryClassPK":"11486"},"javaClass":"java.util.HashMap"}
###

We should use "userId":"10205" as like search because it used quotes around userId "10205", this can avoid the similiar userId 12345 and 123456 returned together. 

**The changed sql will be 'where workflowContext  like '%"userId":"10205"%'**

So I want to replace  https://github.com/marcellustavares/liferay-plugins/pull/298 with the current pull reuqest.

Thanks,
Hai