### PR TITLE
[Technical Support] LPS-59502 

### DIFF
--- a/webs/resources-importer-web/docroot/WEB-INF/src/com/liferay/resourcesimporter/util/BaseImporter.java
+++ b/webs/resources-importer-web/docroot/WEB-INF/src/com/liferay/resourcesimporter/util/BaseImporter.java
@@ -25,6 +25,9 @@ import com.liferay.portal.model.LayoutPrototype;
 import com.liferay.portal.model.LayoutSetPrototype;
 import com.liferay.portal.model.LayoutTypePortlet;
 import com.liferay.portal.model.User;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.security.permission.PermissionThreadLocal;
 import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutPrototypeLocalServiceUtil;
@@ -50,6 +53,11 @@ public abstract class BaseImporter implements Importer {
 		User user = UserLocalServiceUtil.getDefaultUser(companyId);
 
 		userId = user.getUserId();
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
 
 		if (isCompanyGroup()) {
 			return;


### PR DESCRIPTION
The pull request extends from https://github.com/matethurzo/liferay-portal/pull/1213#issuecomment-149889162.

Mate suggest we should initialize permissionchecker in messageListener. So I add the logic in here. Please refer to the invoke logic:

ResourcesImporterHotDeployMessageListener.importResources()->ImporterFactory.createImporter()->configureImporter() (importer.afterPropertiesSet();)-> BaseImporter.afterPropertiesSet()

In addition, I checked the similar case (for webDav), we also add the logic in WebDAVServlet.service().
But this has a little difference from Resources Importer. In Resources Importer, we use defaultUser and it is a guest user. I am considering that we can assign guest permission by resource-actions when initialize default data when first startup portal. From theoretically spoken, guest user shouldn't own the permission.

Thanks,
Hai